### PR TITLE
Add link to the matrix spec for each endpoint.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,4 +42,6 @@ pub mod r0 {
 }
 
 /// GET /_matrix/client/versions
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-versions)
 pub mod supported_versions;

--- a/src/r0/account.rs
+++ b/src/r0/account.rs
@@ -1,6 +1,8 @@
 //! Endpoints for account registration and management.
 
 /// POST /_matrix/client/r0/register
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-register)
 pub mod register {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -57,6 +59,8 @@ pub mod register {
 }
 
 /// POST /_matrix/client/r0/account/password/email/requestToken
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-password-email-requesttoken)
 pub mod request_password_change_token {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -91,6 +95,8 @@ pub mod request_password_change_token {
 }
 
 /// POST /_matrix/client/r0/account/deactivate
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-deactivate)
 pub mod deactivate {
     /// Details about this API endpoint.
     pub struct Endpoint;
@@ -116,6 +122,8 @@ pub mod deactivate {
 }
 
 /// POST /_matrix/client/r0/account/password
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-password)
 pub mod change_password {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -147,6 +155,8 @@ pub mod change_password {
 }
 
 /// POST /_matrix/client/r0/register/email/requestToken
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-register-email-requesttoken)
 pub mod request_register_token {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/r0/alias.rs
+++ b/src/r0/alias.rs
@@ -3,6 +3,8 @@
 use ruma_identifiers::RoomAliasId;
 
 /// PUT /_matrix/client/r0/directory/room/:room_alias
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-directory-room-roomalias)
 pub mod create {
     use ruma_identifiers::RoomId;
 
@@ -36,6 +38,8 @@ pub mod create {
 }
 
 /// DELETE /_matrix/client/r0/directory/room/:room_alias
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#delete-matrix-client-r0-directory-room-roomalias)
 pub mod delete {
     /// Details about this API endpoint.
     pub struct Endpoint;
@@ -61,6 +65,8 @@ pub mod delete {
 }
 
 /// GET /_matrix/client/r0/directory/room/:room_alias
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-directory-room-roomalias)
 pub mod get {
     use ruma_identifiers::RoomId;
 

--- a/src/r0/config.rs
+++ b/src/r0/config.rs
@@ -1,6 +1,8 @@
 //! Endpoints for client configuration.
 
 /// PUT /_matrix/client/r0/user/:user_id/rooms/:room_id/account_data/:type
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-user-userid-rooms-roomid-account-data-type)
 pub mod set_room_account_data {
     use ruma_identifiers::{RoomId, UserId};
 
@@ -41,6 +43,8 @@ pub mod set_room_account_data {
 }
 
 /// PUT /_matrix/client/r0/user/:user_id/account_data/:type
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-user-userid-account-data-type)
 pub mod set_global_account_data  {
     use ruma_identifiers::UserId;
 

--- a/src/r0/contact.rs
+++ b/src/r0/contact.rs
@@ -1,6 +1,8 @@
 //! Endpoints for account contact information.
 
 /// POST /_matrix/client/r0/account/3pid
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-3pid)
 pub mod add_contact {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -41,6 +43,8 @@ pub mod add_contact {
 }
 
 /// GET /_matrix/client/r0/account/3pid
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-account-3pid)
 pub mod get_contacts {
     /// Details about this API endpoint.
     pub struct Endpoint;
@@ -86,6 +90,8 @@ pub mod get_contacts {
 }
 
 /// POST /_matrix/client/r0/account/3pid/email/requestToken
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-3pid-email-requesttoken)
 pub mod request_contact_verification_token {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/r0/context.rs
+++ b/src/r0/context.rs
@@ -1,6 +1,8 @@
 //! Endpoints for event context.
 
 /// GET /_matrix/client/r0/rooms/:room_id/context/:event_id
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-context-eventid)
 pub mod get_context {
     use ruma_identifiers::{EventId, RoomId};
     use ruma_events::collections::only;

--- a/src/r0/membership.rs
+++ b/src/r0/membership.rs
@@ -16,6 +16,8 @@ pub struct ThirdPartySigned {
 }
 
 /// POST /_matrix/client/r0/rooms/{roomId}/invite
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-rooms-roomid-invite)
 pub mod invite {
     use ruma_identifiers::RoomId;
 
@@ -58,6 +60,8 @@ pub mod invite {
 }
 
 /// POST /_matrix/client/r0/join/{roomIdOrAlias}
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-join-roomidoralias)
 pub mod join_by_room_id_or_alias {
     use ruma_identifiers::{RoomId, RoomIdOrAliasId};
     use super::ThirdPartySigned;
@@ -117,6 +121,8 @@ pub mod join_by_room_id_or_alias {
 }
 
 /// POST /_matrix/client/r0/rooms/{roomId}/join
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-rooms-roomid-join)
 pub mod join_by_room_id {
     use ruma_identifiers::RoomId;
     use super::ThirdPartySigned;
@@ -166,6 +172,8 @@ pub mod join_by_room_id {
 }
 
 /// POST /_matrix/client/r0/rooms/{roomId}/forget
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-rooms-roomid-forget)
 pub mod forget {
     use ruma_identifiers::RoomId;
 
@@ -202,6 +210,8 @@ pub mod forget {
 }
 
 /// POST /_matrix/client/r0/rooms/{roomId}/leave
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-rooms-roomid-leave)
 pub mod leave {
     use ruma_identifiers::RoomId;
 
@@ -238,6 +248,8 @@ pub mod leave {
 }
 
 /// POST /_matrix/client/r0/rooms/{roomId}/kick
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-rooms-roomid-kick)
 pub mod kick {
     use ruma_identifiers::RoomId;
 
@@ -281,6 +293,8 @@ pub mod kick {
 }
 
 /// POST /_matrix/client/r0/rooms/{roomId}/unban
+///
+/// [matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-rooms-roomid-unban)
 pub mod unban {
     use ruma_identifiers::RoomId;
 
@@ -323,6 +337,8 @@ pub mod unban {
 }
 
 /// POST /_matrix/client/r0/rooms/{roomId}/ban
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-rooms-roomid-ban)
 pub mod ban {
     use ruma_identifiers::RoomId;
 

--- a/src/r0/room.rs
+++ b/src/r0/room.rs
@@ -1,6 +1,8 @@
 //! Endpoints for room creation.
 
 /// POST /_matrix/client/r0/createRoom
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-createroom)
 pub mod create_room {
     use ruma_identifiers::RoomId;
 

--- a/src/r0/session.rs
+++ b/src/r0/session.rs
@@ -1,6 +1,8 @@
 //! Endpoints for user session management.
 
 /// POST /_matrix/client/r0/login
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-login)
 pub mod login {
     /// Details about this API endpoint.
     pub struct Endpoint;
@@ -35,6 +37,8 @@ pub mod login {
 }
 
 /// POST /_matrix/client/r0/logout
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-logout)
 pub mod logout {
     /// Details about this API endpoint.
     pub struct Endpoint;
@@ -60,6 +64,8 @@ pub mod logout {
 }
 
 ///  POST /_matrix/client/r0/tokenrefresh
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-tokenrefresh)
 pub mod refresh_access_token {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
I opted for adding a `[Matrix spec link(...)]` in the documentation of each endpoint. It seems both simple and clear to me.

The URLs are pretty long, so the markdown text ends-up pretty large, is it ok, or should something (but what ?) be done about that?

Fixes #2 