### PR TITLE
Add more endpoints (publicrooms, profile, filter, events)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod r0 {
     pub mod contact;
     pub mod context;
     pub mod directory;
+    pub mod events;
     pub mod filter;
     pub mod media;
     pub mod membership;

--- a/src/r0/account.rs
+++ b/src/r0/account.rs
@@ -7,8 +7,10 @@ pub mod register {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub bind_email: Option<bool>,
         pub password: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub username: Option<String>,
     }
 
@@ -16,8 +18,9 @@ pub mod register {
     pub struct Endpoint;
 
     /// This API endpoint's query string parameters.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct QueryParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub kind: Option<RegistrationKind>,
     }
 
@@ -67,6 +70,7 @@ pub mod request_password_change_token {
     pub struct BodyParams {
         pub client_secret: String,
         pub email: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub id_server: Option<String>,
         pub send_attempt: u64,
     }
@@ -163,6 +167,7 @@ pub mod request_register_token {
     pub struct BodyParams {
         pub client_secret: String,
         pub email: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub id_server: Option<String>,
         pub send_attempt: u64,
     }

--- a/src/r0/alias.rs
+++ b/src/r0/alias.rs
@@ -101,6 +101,7 @@ pub mod get {
 }
 
 /// These API endpoints' path parameters.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PathParams {
     pub room_alias: RoomAliasId,
 }

--- a/src/r0/contact.rs
+++ b/src/r0/contact.rs
@@ -7,6 +7,7 @@ pub mod add_contact {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub bind: Option<bool>,
         pub three_pid_creds: ThreePidCredentials,
     }
@@ -98,6 +99,7 @@ pub mod request_contact_verification_token {
     pub struct BodyParams {
         pub client_secret: String,
         pub email: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub id_server: Option<String>,
         pub send_attempt: u64,
     }

--- a/src/r0/context.rs
+++ b/src/r0/context.rs
@@ -19,7 +19,7 @@ pub mod get_context {
     }
 
     /// This API endpoint's query string parameters.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct QueryParams {
         pub limit: u8,
     }

--- a/src/r0/directory.rs
+++ b/src/r0/directory.rs
@@ -10,12 +10,15 @@ pub mod public_rooms {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct PublicRoomsChunk {
         pub world_readable: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub topic: Option<String>,
         pub num_joined_members: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub avatar_url: Option<String>,
         pub room_id: RoomId,
         pub guest_can_join: bool,
         pub aliases: Vec<RoomAliasId>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub name: Option<String>
     }
 

--- a/src/r0/directory.rs
+++ b/src/r0/directory.rs
@@ -1,1 +1,51 @@
 //! Endpoints for the public room directory.
+
+/// GET /_matrix/client/r0/publicRooms
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-publicrooms)
+pub mod public_rooms {
+    use ruma_identifiers::{RoomId, RoomAliasId};
+
+    /// A chunk of the response, describing one room
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PublicRoomsChunk {
+        pub world_readable: bool,
+        pub topic: Option<String>,
+        pub num_joined_members: u64,
+        pub avatar_url: Option<String>,
+        pub room_id: RoomId,
+        pub guest_can_join: bool,
+        pub aliases: Vec<RoomAliasId>,
+        pub name: Option<String>
+    }
+
+    /// This API response type
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Response {
+        pub start: String,
+        pub chunk: Vec<PublicRoomsChunk>,
+        pub end: String
+    }
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = ();
+        type QueryParams = ();
+        type Response = Response;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(_params: Self::PathParams) -> String {
+            Self::router_path()
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/publicRooms".to_string()
+        }
+    }
+}

--- a/src/r0/events.rs
+++ b/src/r0/events.rs
@@ -1,0 +1,233 @@
+//! Endpoints for getting events
+
+/// GET /_matrix/client/r0/rooms/{roomId}/state
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-state)
+pub mod get_full_state {
+    use ruma_identifiers::RoomId;
+    use ruma_events::collections::only;
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub room_id: RoomId
+    }
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = Vec<only::StateEvent>;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/rooms/{}/state",
+                params.room_id
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/rooms/:room_id/state".to_string()
+        }
+    }
+}
+
+/// GET /_matrix/client/r0/rooms/{roomId}/state/{eventType}
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-state-eventtype)
+pub mod get_state_for_empty_key {
+    use ruma_identifiers::RoomId;
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub room_id: RoomId,
+        pub event_type: String
+    }
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = ::serde_json::Value;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/rooms/{}/state/{}",
+                params.room_id,
+                params.event_type
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/rooms/:room_id/state/:event_type".to_string()
+        }
+    }
+}
+
+/// GET /_matrix/client/r0/rooms/{roomId}/state/{eventType}/{stateKey}
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-state-eventtype-state-key)
+pub mod get_state_for_key {
+    use ruma_identifiers::RoomId;
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub room_id: RoomId,
+        pub event_type: String,
+        pub state_key: String,
+    }
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = ::serde_json::Value;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/rooms/{}/state/{}/{}",
+                params.room_id,
+                params.event_type,
+                params.state_key
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/rooms/:room_id/state/:event_type/:state_key".to_string()
+        }
+    }
+}
+
+/// GET /_matrix/client/r0/rooms/{roomId}/members
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-members)
+pub mod get_members {
+    use ruma_identifiers::RoomId;
+    use ruma_events::room::member::MemberEvent;
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub room_id: RoomId,
+        pub event_type: String
+    }
+    
+    /// This API endpoint's reponse.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Response {
+        pub chunks: Vec<MemberEvent>
+    }
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = Response;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/rooms/{}/members",
+                params.room_id,
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/rooms/:room_id/members".to_string()
+        }
+    }
+}
+
+/// GET /_matrix/client/r0/rooms/{roomId}/messages
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-messages)
+pub mod get_messages {
+    use ruma_identifiers::RoomId;
+    use ruma_events::collections::only;
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub room_id: RoomId,
+        pub event_type: String
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub enum Direction {
+        #[serde(rename="b")]
+        Backward,
+        #[serde(rename="f")]
+        Forward
+    }
+
+    /// This API endpoint's query parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct QueryParams {
+        pub from: String,
+        pub to: Option<String>,
+        pub dir: Direction,
+        pub limit: Option<u64>
+    }
+    
+    /// This API endpoint's reponse.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Response {
+        pub start: String,
+        pub chunks: Vec<only::RoomEvent>,
+        pub end: String
+    }
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = QueryParams;
+        type Response = Response;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/rooms/{}/messages",
+                params.room_id,
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/rooms/:room_id/messages".to_string()
+        }
+    }
+}

--- a/src/r0/events.rs
+++ b/src/r0/events.rs
@@ -196,8 +196,10 @@ pub mod get_messages {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct QueryParams {
         pub from: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub to: Option<String>,
         pub dir: Direction,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub limit: Option<u64>
     }
     

--- a/src/r0/filter.rs
+++ b/src/r0/filter.rs
@@ -102,7 +102,7 @@ pub mod create_filter {
     }
 }
 
-/// POST /_matrix/client/r0/user/{userId}/filter/{filterId}
+/// GET /_matrix/client/r0/user/{userId}/filter/{filterId}
 ///
 /// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-user-userid-filter-filterid)
 pub mod get_filter {

--- a/src/r0/filter.rs
+++ b/src/r0/filter.rs
@@ -1,1 +1,144 @@
 //! Endpoints for event filters.
+
+use ruma_identifiers::{RoomId, UserId};
+
+/// Format to use for returned events
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub enum EventFormat {
+    /// Client format, as described in the Client API
+    #[serde(rename="client")]
+    Client,
+    /// Raw events from federation
+    #[serde(rename="federation")]
+    Federation
+}
+
+/// Filters to be applied to room events
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RoomEventFilter {
+    pub not_types: Option<Vec<String>>,
+    pub not_rooms: Option<Vec<String>>,
+    pub limit: Option<u64>,
+    pub rooms: Option<Vec<RoomId>>,
+    pub not_senders: Option<Vec<UserId>>,
+    pub senders: Option<Vec<UserId>>,
+    pub types: Option<Vec<String>>
+}
+
+/// Filters to be applied to room data
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RoomFilter {
+    pub include_leave: Option<bool>,
+    pub account_data: Option<RoomEventFilter>,
+    pub timeline: Option<RoomEventFilter>,
+    pub ephemeral: Option<RoomEventFilter>,
+    pub state: Option<RoomEventFilter>,
+    pub not_rooms: Option<Vec<RoomId>>,
+    pub room: Option<Vec<RoomId>>
+}
+
+/// Filter for not-room data
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Filter {
+    pub not_types: Option<Vec<String>>,
+    pub limit: Option<u64>,
+    pub senders: Option<Vec<UserId>>,
+    pub types: Option<Vec<String>>,
+    pub not_senders: Option<Vec<UserId>>
+}
+
+/// A filter definition
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FilterDefinition {
+    pub event_fields: Option<Vec<String>>,
+    pub event_format: Option<EventFormat>,
+    pub account_data: Option<Filter>,
+    pub room: Option<RoomFilter>,
+    pub presence: Option<Filter>
+}
+
+/// POST /_matrix/client/r0/user/{userId}/filter
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-user-userid-filter)
+pub mod create_filter {
+    use ruma_identifiers::UserId;
+    use super::FilterDefinition;
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub user_id: UserId
+    }
+
+    /// This API Response.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Response {
+        pub filter_id: String
+    }
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = FilterDefinition;
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = Response;
+
+        fn method() -> ::Method {
+            ::Method::Post
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/user/{}/filter",
+                params.user_id
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/user/:user_id/filter".to_string()
+        }
+    }
+}
+
+/// POST /_matrix/client/r0/user/{userId}/filter/{filterId}
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-user-userid-filter-filterid)
+pub mod get_filter {
+    use ruma_identifiers::UserId;
+    use super::FilterDefinition;
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub user_id: UserId,
+        pub filter_id: String
+    }
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = FilterDefinition;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/user/{}/filter/{}",
+                params.user_id,
+                params.filter_id
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/user/:user_id/filter/:filter_id".to_string()
+        }
+    }
+}

--- a/src/r0/filter.rs
+++ b/src/r0/filter.rs
@@ -16,44 +16,81 @@ pub enum EventFormat {
 /// Filters to be applied to room events
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RoomEventFilter {
-    pub not_types: Option<Vec<String>>,
-    pub not_rooms: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub not_types: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub not_rooms: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u64>,
-    pub rooms: Option<Vec<RoomId>>,
-    pub not_senders: Option<Vec<UserId>>,
-    pub senders: Option<Vec<UserId>>,
-    pub types: Option<Vec<String>>
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub rooms: Vec<RoomId>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub not_senders: Vec<UserId>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub senders: Vec<UserId>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub types: Vec<String>
 }
 
 /// Filters to be applied to room data
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RoomFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub include_leave: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_data: Option<RoomEventFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeline: Option<RoomEventFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ephemeral: Option<RoomEventFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<RoomEventFilter>,
-    pub not_rooms: Option<Vec<RoomId>>,
-    pub room: Option<Vec<RoomId>>
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub not_rooms: Vec<RoomId>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub room: Vec<RoomId>
 }
 
 /// Filter for not-room data
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Filter {
-    pub not_types: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub not_types: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u64>,
-    pub senders: Option<Vec<UserId>>,
-    pub types: Option<Vec<String>>,
-    pub not_senders: Option<Vec<UserId>>
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub senders: Vec<UserId>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub types: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub not_senders: Vec<UserId>
 }
 
 /// A filter definition
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FilterDefinition {
-    pub event_fields: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub event_fields: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event_format: Option<EventFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_data: Option<Filter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub room: Option<RoomFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub presence: Option<Filter>
 }
 

--- a/src/r0/membership.rs
+++ b/src/r0/membership.rs
@@ -69,6 +69,7 @@ pub mod join_by_room_id_or_alias {
     /// The request type.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub third_party_signed: Option<ThirdPartySigned>,
     }
 
@@ -130,6 +131,7 @@ pub mod join_by_room_id {
     /// The request type.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub third_party_signed: Option<ThirdPartySigned>,
     }
 
@@ -257,6 +259,7 @@ pub mod kick {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
         pub user_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>,
     }
 
@@ -345,6 +348,7 @@ pub mod ban {
     /// The request type.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>,
         pub user_id: String,
     }

--- a/src/r0/presence.rs
+++ b/src/r0/presence.rs
@@ -19,6 +19,7 @@ pub mod set_presence {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         status_msg: Option<String>,
         presence: PresenceState
     }
@@ -65,8 +66,11 @@ pub mod get_presence {
     /// This API endpoint's response.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Response {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub status_msg: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub currently_active: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub last_active_ago: Option<u64>,
         pub presence: PresenceState
     }
@@ -112,8 +116,12 @@ pub mod update_presence_list {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
-        drop: Option<Vec<UserId>>,
-        invite: Option<Vec<UserId>>
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(default)]
+        drop: Vec<UserId>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(default)]
+        invite: Vec<UserId>
     }
 
     impl ::Endpoint for Endpoint {

--- a/src/r0/profile.rs
+++ b/src/r0/profile.rs
@@ -1,1 +1,223 @@
 //! Endpoints for user profiles.
+
+/// GET /_matrix/client/r0/profile/{userId}/displayname
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-profile-userid-displayname)
+pub mod get_display_name {
+    use ruma_identifiers::UserId;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub user_id: UserId
+    }
+
+    /// This API endpoint's body parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Response {
+        pub displayname: Option<String>
+    }
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = Response;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/profile/{}/displayname",
+                params.user_id
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/profile/:user_id/displayname".to_string()
+        }
+    }
+}
+
+
+/// PUT /_matrix/client/r0/profile/{userId}/displayname
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-profile-userid-displayname)
+pub mod set_display_name {
+    use ruma_identifiers::UserId;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub user_id: UserId
+    }
+
+    /// This API endpoint's body parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct BodyParams {
+        pub displayname: Option<String>
+    }
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = BodyParams;
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = ();
+
+        fn method() -> ::Method {
+            ::Method::Put
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/profile/{}/displayname",
+                params.user_id
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/profile/:user_id/displayname".to_string()
+        }
+    }
+}
+
+/// GET /_matrix/client/r0/profile/{userId}/avatar_url
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-profile-userid-avatar-url)
+pub mod get_avatar_url {
+    use ruma_identifiers::UserId;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub user_id: UserId
+    }
+
+    /// This API endpoint's body parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Response {
+        pub avatar_url: Option<String>
+    }
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = Response;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/profile/{}/avatar_url",
+                params.user_id
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/profile/:user_id/avatar_url".to_string()
+        }
+    }
+}
+
+/// PUT /_matrix/client/r0/profile/{userId}/avatar_url
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-profile-userid-avatar-url)
+pub mod set_avatar_url {
+    use ruma_identifiers::UserId;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub user_id: UserId
+    }
+
+    /// This API endpoint's body parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct BodyParams {
+        pub avatar_url: Option<String>
+    }
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = BodyParams;
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = ();
+
+        fn method() -> ::Method {
+            ::Method::Put
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/profile/{}/avatar_url",
+                params.user_id
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/profile/:user_id/avatar_url".to_string()
+        }
+    }
+}
+
+/// GET /_matrix/client/r0/profile/{userId}
+///
+/// [Matrix spec link](http://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-profile-userid)
+pub mod get_profile {
+    use ruma_identifiers::UserId;
+
+    /// This API endpoint's path parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct PathParams {
+        pub user_id: UserId
+    }
+
+    /// This API endpoint's body parameters.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Response {
+        pub avatar_url: Option<String>,
+        pub displayname: Option<String>
+    }
+
+    /// Details about this API endpoint.
+    pub struct Endpoint;
+
+    impl ::Endpoint for Endpoint {
+        type BodyParams = ();
+        type PathParams = PathParams;
+        type QueryParams = ();
+        type Response = Response;
+
+        fn method() -> ::Method {
+            ::Method::Get
+        }
+
+        fn request_path(params: Self::PathParams) -> String {
+            format!(
+                "/_matrix/client/r0/profile/{}",
+                params.user_id
+            )
+        }
+
+        fn router_path() -> String {
+            "/_matrix/client/r0/profile/:user_id".to_string()
+        }
+    }
+}

--- a/src/r0/profile.rs
+++ b/src/r0/profile.rs
@@ -15,6 +15,7 @@ pub mod get_display_name {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Response {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub displayname: Option<String>
     }
 
@@ -60,6 +61,7 @@ pub mod set_display_name {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub displayname: Option<String>
     }
 
@@ -104,6 +106,7 @@ pub mod get_avatar_url {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Response {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub avatar_url: Option<String>
     }
 
@@ -148,6 +151,7 @@ pub mod set_avatar_url {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub avatar_url: Option<String>
     }
 
@@ -192,7 +196,9 @@ pub mod get_profile {
     /// This API endpoint's body parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Response {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub avatar_url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub displayname: Option<String>
     }
 

--- a/src/r0/redact.rs
+++ b/src/r0/redact.rs
@@ -20,6 +20,7 @@ pub mod send_event {
     /// This API endpoint's path parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>
     }
 

--- a/src/r0/room.rs
+++ b/src/r0/room.rs
@@ -9,12 +9,20 @@ pub mod create_room {
     /// The request type.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub creation_content: Option<CreationContent>,
-        pub invite: Option<Vec<String>>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(default)]
+        pub invite: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub preset: Option<RoomPreset>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub room_alias_name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub topic: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub visibility: Option<String>,
     }
 
@@ -22,6 +30,7 @@ pub mod create_room {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct CreationContent {
         #[serde(rename="m.federate")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub federate: Option<bool>,
     }
 

--- a/src/r0/session.rs
+++ b/src/r0/session.rs
@@ -12,6 +12,7 @@ pub mod login {
     pub struct Response {
         pub access_token: String,
         pub home_server: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub refresh_token: Option<String>,
         pub user_id: String,
     }
@@ -80,6 +81,7 @@ pub mod refresh_access_token {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Response {
         pub access_token: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub refresh_token: Option<String>,
     }
 

--- a/src/r0/sync.rs
+++ b/src/r0/sync.rs
@@ -21,10 +21,15 @@ pub mod sync {
     /// This API endpoint's query parameters.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct QueryParams {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub filter: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub since: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub full_state: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub set_presence: Option<SetPresence>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub timeout: Option<u64>
     }
 

--- a/src/r0/typing.rs
+++ b/src/r0/typing.rs
@@ -20,6 +20,7 @@ pub mod set_typing {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BodyParams {
         pub typing: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub timeout: Option<u64>
     }
 


### PR DESCRIPTION
This PR adds, separated in commits, the endpoints:

- for directory querying
   - `GET /_matrix/client/r0/publicRooms`
- for profile querying and updating
   - `GET /_matrix/client/r0/profile/{userId}/displayname`
   - `PUT /_matrix/client/r0/profile/{userId}/displayname`
   - `GET /_matrix/client/r0/profile/{userId}/avatar_url`
   - `PUT /_matrix/client/r0/profile/{userId}/avatar_url`
   - `GET /_matrix/client/r0/profile/{userId}`
- for filtering
   - `POST /_matrix/client/r0/user/{userId}/filter`
   - `GET /_matrix/client/r0/user/{userId}/filter/{filterId}`
- for event retrieving in rooms
   - `GET /_matrix/client/r0/rooms/{roomId}/state`
   - `GET /_matrix/client/r0/rooms/{roomId}/state/{eventType}`
   - `GET /_matrix/client/r0/rooms/{roomId}/state/{eventType}/{stateKey}`
   - `GET /_matrix/client/r0/rooms/{roomId}/members`
   - `GET /_matrix/client/r0/rooms/{roomId}/messages`

If I didn't miss any, all non-deprecated and non-module endpoints should be implemented with this merged.