### PR TITLE
Remove unused event_type parameter

### DIFF
--- a/src/r0/events.rs
+++ b/src/r0/events.rs
@@ -135,7 +135,6 @@ pub mod get_members {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct PathParams {
         pub room_id: RoomId,
-        pub event_type: String
     }
     
     /// This API endpoint's reponse.


### PR DESCRIPTION
According to the spec the room members endpoint does not have an event_type parameter in the path, it is also not used in the `request_path` method.