### PR TITLE
Convert path parameters in docs from colon-snake-case to brace-lower-camel-case

### DIFF
--- a/src/r0/alias.rs
+++ b/src/r0/alias.rs
@@ -2,7 +2,7 @@
 
 use ruma_identifiers::RoomAliasId;
 
-/// [PUT /_matrix/client/r0/directory/room/:room_alias](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-directory-room-roomalias)
+/// [PUT /_matrix/client/r0/directory/room/{roomAlias}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-directory-room-roomalias)
 pub mod create_alias {
     use ruma_identifiers::RoomId;
 
@@ -36,7 +36,7 @@ pub mod create_alias {
     }
 }
 
-/// [DELETE /_matrix/client/r0/directory/room/:room_alias](https://matrix.org/docs/spec/client_server/r0.2.0.html#delete-matrix-client-r0-directory-room-roomalias)
+/// [DELETE /_matrix/client/r0/directory/room/{roomAlias}](https://matrix.org/docs/spec/client_server/r0.2.0.html#delete-matrix-client-r0-directory-room-roomalias)
 pub mod delete_alias {
     /// Details about this API endpoint.
     #[derive(Clone, Copy, Debug)]
@@ -62,7 +62,7 @@ pub mod delete_alias {
     }
 }
 
-/// [GET /_matrix/client/r0/directory/room/:room_alias](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-directory-room-roomalias)
+/// [GET /_matrix/client/r0/directory/room/{roomAlias}](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-directory-room-roomalias)
 pub mod get_alias {
     use ruma_identifiers::RoomId;
 

--- a/src/r0/config.rs
+++ b/src/r0/config.rs
@@ -1,6 +1,6 @@
 //! Endpoints for client configuration.
 
-/// [PUT /_matrix/client/r0/user/:user_id/rooms/:room_id/account_data/:type](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-user-userid-rooms-roomid-account-data-type)
+/// [PUT /_matrix/client/r0/user/{userId}/rooms/{roomId}/account_data/{type}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-user-userid-rooms-roomid-account-data-type)
 pub mod set_room_account_data {
     use ruma_identifiers::{RoomId, UserId};
 
@@ -41,7 +41,7 @@ pub mod set_room_account_data {
     }
 }
 
-/// [PUT /_matrix/client/r0/user/:user_id/account_data/:type](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-user-userid-account-data-type)
+/// [PUT /_matrix/client/r0/user/{userId}/account_data/{type}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-user-userid-account-data-type)
 pub mod set_global_account_data  {
     use ruma_identifiers::UserId;
 

--- a/src/r0/context.rs
+++ b/src/r0/context.rs
@@ -1,6 +1,6 @@
 //! Endpoints for event context.
 
-/// [GET /_matrix/client/r0/rooms/:room_id/context/:event_id](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-context-eventid)
+/// [GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-context-eventid)
 pub mod get_context {
     use ruma_identifiers::{EventId, RoomId};
     use ruma_events::collections::only;


### PR DESCRIPTION
I think there are no more of them in the docs!

Fixes #9 