### PR TITLE
RoomFilter: fix typo

### DIFF
--- a/src/r0/filter.rs
+++ b/src/r0/filter.rs
@@ -97,7 +97,7 @@ pub struct RoomFilter {
     /// filters in `ephemeral`, `state`, `timeline` or `account_data`.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
-    pub room: Vec<RoomId>,
+    pub rooms: Vec<RoomId>,
 }
 
 /// Filter for not-room data


### PR DESCRIPTION
nevertheless a breaking change.

But I guess some other breakings will arise from the move to [ruma-api-macros 0.2.0](https://github.com/ruma/ruma-api-macros/releases/tag/0.2.0) anyway.

Is there a place to note down stuff like this? I can start a CHANGELOG.md like https://keepachangelog.com/ if that's wanted.

Source: https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter