### PR TITLE
/rooms/{room_id}/members requires authentication

### DIFF
--- a/src/r0/sync.rs
+++ b/src/r0/sync.rs
@@ -113,10 +113,7 @@ pub mod get_member_events {
             name: "get_member_events",
             path: "/_matrix/client/r0/rooms/:room_id/members",
             rate_limited: false,
-            requires_authentication: false,
-            // TODO: not marked as requiring auth in the spec, but
-            // will return a 403 error is user is not a member of the
-            // room anyway...
+            requires_authentication: true,
         }
 
         request {


### PR DESCRIPTION
it was just an omission from the spec.
See https://github.com/matrix-org/matrix-doc/pull/1244 (not yet merged as of now, but already confirmed as omission).