### PR TITLE
Update to Rust 2018

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+merge_imports = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "ruma-client-api"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma-client-api"
 version = "0.2.0"
+edition = "2018"
 
 [dependencies]
 futures = "0.1.25"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,20 +5,14 @@
 #![deny(missing_debug_implementations, missing_docs)]
 #![feature(try_from)]
 
-extern crate futures;
-extern crate http;
-extern crate hyper;
-extern crate ruma_api;
-extern crate ruma_api_macros;
-extern crate ruma_events;
-extern crate ruma_identifiers;
-extern crate ruma_signatures;
-extern crate serde;
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_urlencoded;
-extern crate url;
+use futures;
+use http;
+use hyper;
+use ruma_api;
+use serde;
+use serde_json;
+use serde_urlencoded;
+use url;
 
 /// Endpoints for the r0.x.x versions of the client API specification.
 pub mod r0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ extern crate ruma_identifiers;
 extern crate ruma_signatures;
 extern crate serde;
 extern crate serde_json;
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_urlencoded;
 extern crate url;
 

--- a/src/r0/account.rs
+++ b/src/r0/account.rs
@@ -81,7 +81,7 @@ pub mod register {
         #[serde(rename = "type")]
         kind: String,
         /// The value of the session key given by the homeserver.
-        session: Option<String>
+        session: Option<String>,
     }
 
     /// The kind of account being registered.
@@ -90,10 +90,10 @@ pub mod register {
         /// A guest account
         ///
         /// These accounts may have limited permissions and may not be supported by all servers.
-        #[serde(rename="guest")]
+        #[serde(rename = "guest")]
         Guest,
         /// A regular user account
-        #[serde(rename="user")]
+        #[serde(rename = "user")]
         User,
     }
 }

--- a/src/r0/account.rs
+++ b/src/r0/account.rs
@@ -4,6 +4,7 @@
 pub mod register {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -101,6 +102,7 @@ pub mod register {
 /// [POST /_matrix/client/r0/account/password/email/requestToken](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-password-email-requesttoken)
 pub mod request_password_change_token {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -153,6 +155,7 @@ pub mod deactivate {
 /// [POST /_matrix/client/r0/account/password](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-password)
 pub mod change_password {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -177,6 +180,7 @@ pub mod change_password {
 /// [POST /_matrix/client/r0/register/email/requestToken](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-register-email-requesttoken)
 pub mod request_register_token {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/alias.rs
+++ b/src/r0/alias.rs
@@ -4,6 +4,7 @@
 pub mod create_alias {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomAliasId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -31,6 +32,7 @@ pub mod create_alias {
 pub mod delete_alias {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::RoomAliasId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -56,6 +58,7 @@ pub mod delete_alias {
 pub mod get_alias {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomAliasId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/config.rs
+++ b/src/r0/config.rs
@@ -4,6 +4,7 @@
 pub mod set_room_account_data {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
     use serde_json::Value;
 
     ruma_api! {
@@ -43,6 +44,7 @@ pub mod set_room_account_data {
 pub mod set_global_account_data {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
     use serde_json::Value;
 
     ruma_api! {

--- a/src/r0/config.rs
+++ b/src/r0/config.rs
@@ -40,7 +40,7 @@ pub mod set_room_account_data {
 }
 
 /// [PUT /_matrix/client/r0/user/{userId}/account_data/{type}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-user-userid-account-data-type)
-pub mod set_global_account_data  {
+pub mod set_global_account_data {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
     use serde_json::Value;

--- a/src/r0/contact.rs
+++ b/src/r0/contact.rs
@@ -3,6 +3,7 @@
 /// [POST /_matrix/client/r0/account/3pid](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-3pid)
 pub mod create_contact {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -43,6 +44,7 @@ pub mod create_contact {
 /// [GET /_matrix/client/r0/account/3pid](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-account-3pid)
 pub mod get_contacts {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -84,6 +86,7 @@ pub mod get_contacts {
 /// [POST /_matrix/client/r0/account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-3pid-email-requesttoken)
 pub mod request_contact_verification_token {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/contact.rs
+++ b/src/r0/contact.rs
@@ -67,7 +67,7 @@ pub mod get_contacts {
     #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
     pub enum Medium {
         /// An email address.
-        #[serde(rename="email")]
+        #[serde(rename = "email")]
         Email,
     }
 

--- a/src/r0/context.rs
+++ b/src/r0/context.rs
@@ -5,6 +5,7 @@ pub mod get_context {
     use ruma_api_macros::ruma_api;
     use ruma_events::collections::only;
     use ruma_identifiers::{EventId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/context.rs
+++ b/src/r0/context.rs
@@ -2,9 +2,9 @@
 
 /// [GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-rooms-roomid-context-eventid)
 pub mod get_context {
-    use ruma_identifiers::{EventId, RoomId};
-    use ruma_events::collections::only;
     use ruma_api_macros::ruma_api;
+    use ruma_events::collections::only;
+    use ruma_identifiers::{EventId, RoomId};
 
     ruma_api! {
         metadata {

--- a/src/r0/directory.rs
+++ b/src/r0/directory.rs
@@ -4,6 +4,7 @@
 pub mod get_public_rooms {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomAliasId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/directory.rs
+++ b/src/r0/directory.rs
@@ -2,8 +2,8 @@
 
 /// [GET /_matrix/client/r0/publicRooms](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-publicrooms)
 pub mod get_public_rooms {
-    use ruma_identifiers::{RoomId, RoomAliasId};
     use ruma_api_macros::ruma_api;
+    use ruma_identifiers::{RoomAliasId, RoomId};
 
     ruma_api! {
         metadata {

--- a/src/r0/filter.rs
+++ b/src/r0/filter.rs
@@ -1,6 +1,7 @@
 //! Endpoints for event filters.
 
 use ruma_identifiers::{RoomId, UserId};
+use serde_derive::{Deserialize, Serialize};
 
 /// Format to use for returned events
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -169,6 +170,7 @@ pub struct FilterDefinition {
 pub mod create_filter {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     use super::FilterDefinition;
 
@@ -204,6 +206,7 @@ pub mod create_filter {
 pub mod get_filter {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     use super::FilterDefinition;
 

--- a/src/r0/media.rs
+++ b/src/r0/media.rs
@@ -3,6 +3,7 @@
 /// [GET /_matrix/media/r0/download/{serverName}/{mediaId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-media-r0-download-servername-mediaid)
 pub mod get_content {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -40,6 +41,7 @@ pub mod get_content {
 /// [POST /_matrix/media/r0/upload](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-media-r0-upload)
 pub mod create_content {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -67,6 +69,7 @@ pub mod create_content {
 /// [GET /_matrix/media/r0/thumbnail/{serverName}/{mediaId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-media-r0-thumbnail-servername-mediaid)
 pub mod get_content_thumbnail {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     /// The desired resizing method.
     #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/src/r0/membership.rs
+++ b/src/r0/membership.rs
@@ -22,7 +22,7 @@ pub struct ThirdPartySigned {
 /// [POST /_matrix/client/r0/rooms/{roomId}/invite](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-rooms-roomid-invite)
 pub mod invite_user {
     use ruma_api_macros::ruma_api;
-    use ruma_identifiers::{UserId, RoomId};
+    use ruma_identifiers::{RoomId, UserId};
 
     ruma_api! {
         metadata {

--- a/src/r0/membership.rs
+++ b/src/r0/membership.rs
@@ -1,6 +1,7 @@
 //! Endpoints for room membership.
 
 use ruma_signatures::Signatures;
+use serde_derive::{Deserialize, Serialize};
 
 // TODO: spec requires a nesting ThirdPartySigned { signed: Signed { mxid: ..., ... } }
 //       for join_room_by_id_or_alias but not for join_room_by_id, inconsistency?
@@ -23,6 +24,7 @@ pub struct ThirdPartySigned {
 pub mod invite_user {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -50,6 +52,7 @@ pub mod invite_user {
 pub mod join_room_by_id_or_alias {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, RoomIdOrAliasId};
+    use serde_derive::{Deserialize, Serialize};
 
     use super::ThirdPartySigned;
 
@@ -84,6 +87,7 @@ pub mod join_room_by_id_or_alias {
 pub mod join_room_by_id {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
     use super::ThirdPartySigned;
 
@@ -118,6 +122,7 @@ pub mod join_room_by_id {
 pub mod forget_room {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -143,6 +148,7 @@ pub mod forget_room {
 pub mod leave_room {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -168,6 +174,7 @@ pub mod leave_room {
 pub mod kick_user {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -198,6 +205,7 @@ pub mod kick_user {
 pub mod unban_user {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -225,6 +233,7 @@ pub mod unban_user {
 pub mod ban_user {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/presence.rs
+++ b/src/r0/presence.rs
@@ -3,8 +3,8 @@
 /// [PUT /_matrix/client/r0/presence/{userId}/status](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-presence-userid-status)
 pub mod set_presence {
     use ruma_api_macros::ruma_api;
-    use ruma_identifiers::UserId;
     use ruma_events::presence::PresenceState;
+    use ruma_identifiers::UserId;
 
     ruma_api! {
         metadata {

--- a/src/r0/presence.rs
+++ b/src/r0/presence.rs
@@ -5,6 +5,7 @@ pub mod set_presence {
     use ruma_api_macros::ruma_api;
     use ruma_events::presence::PresenceState;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -36,6 +37,7 @@ pub mod get_presence {
     use ruma_api_macros::ruma_api;
     use ruma_events::presence::PresenceState;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -73,6 +75,7 @@ pub mod get_presence {
 pub mod update_presence_subscriptions {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -107,6 +110,7 @@ pub mod get_subscribed_presences {
     use ruma_api_macros::ruma_api;
     use ruma_events::presence::PresenceEvent;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/profile.rs
+++ b/src/r0/profile.rs
@@ -4,6 +4,7 @@
 pub mod get_display_name {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -33,6 +34,7 @@ pub mod get_display_name {
 pub mod set_display_name {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -61,6 +63,7 @@ pub mod set_display_name {
 pub mod get_avatar_url {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -90,6 +93,7 @@ pub mod get_avatar_url {
 pub mod set_avatar_url {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -117,6 +121,7 @@ pub mod set_avatar_url {
 pub mod get_profile {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/receipt.rs
+++ b/src/r0/receipt.rs
@@ -6,6 +6,7 @@ pub mod create_receipt {
 
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{EventId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -41,7 +42,7 @@ pub mod create_receipt {
     }
 
     impl Display for ReceiptType {
-        fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
             match *self {
                 ReceiptType::Read => write!(f, "m.read"),
             }

--- a/src/r0/redact.rs
+++ b/src/r0/redact.rs
@@ -3,7 +3,7 @@
 /// [PUT /_matrix/client/r0/rooms/{roomId}/redact/{eventId}/{txnId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-redact-eventid-txnid)
 pub mod redact_event {
     use ruma_api_macros::ruma_api;
-    use ruma_identifiers::{RoomId, EventId};
+    use ruma_identifiers::{EventId, RoomId};
 
     ruma_api! {
         metadata {

--- a/src/r0/redact.rs
+++ b/src/r0/redact.rs
@@ -4,6 +4,7 @@
 pub mod redact_event {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{EventId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/room.rs
+++ b/src/r0/room.rs
@@ -4,6 +4,7 @@
 pub mod create_room {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/room.rs
+++ b/src/r0/room.rs
@@ -2,8 +2,8 @@
 
 /// [POST /_matrix/client/r0/createRoom](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-createroom)
 pub mod create_room {
-    use ruma_identifiers::{RoomId, UserId};
     use ruma_api_macros::ruma_api;
+    use ruma_identifiers::{RoomId, UserId};
 
     ruma_api! {
         metadata {
@@ -59,7 +59,7 @@ pub mod create_room {
         /// Whether users on other servers can join this room.
         ///
         /// Defaults to `true` if key does not exist.
-        #[serde(rename="m.federate")]
+        #[serde(rename = "m.federate")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub federate: Option<bool>,
     }
@@ -68,13 +68,13 @@ pub mod create_room {
     #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
     pub enum RoomPreset {
         /// `join_rules` is set to `invite` and `history_visibility` is set to `shared`.
-        #[serde(rename="private_chat")]
+        #[serde(rename = "private_chat")]
         PrivateChat,
         /// `join_rules` is set to `public` and `history_visibility` is set to `shared`.
-        #[serde(rename="public_chat")]
+        #[serde(rename = "public_chat")]
         PublicChat,
         /// Same as `PrivateChat`, but all initial invitees get the same power level as the creator.
-        #[serde(rename="trusted_private_chat")]
+        #[serde(rename = "trusted_private_chat")]
         TrustedPrivateChat,
     }
 

--- a/src/r0/search.rs
+++ b/src/r0/search.rs
@@ -7,8 +7,9 @@ pub mod search_events {
     use ruma_api_macros::ruma_api;
     use ruma_events::collections::all::Event;
     use ruma_identifiers::{EventId, RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
-    use r0::filter::RoomEventFilter;
+    use crate::r0::filter::RoomEventFilter;
 
     ruma_api! {
         metadata {

--- a/src/r0/search.rs
+++ b/src/r0/search.rs
@@ -41,7 +41,7 @@ pub mod search_events {
     pub struct Categories {
         /// Criteria for searching a category of events.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub room_events: Option<Criteria>
+        pub room_events: Option<Criteria>,
     }
 
     /// Criteria for searching a category of events.
@@ -107,17 +107,17 @@ pub mod search_events {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Grouping {
         /// The key within events to use for this grouping.
-        pub key: GroupingKey
+        pub key: GroupingKey,
     }
 
     /// The key within events to use for this grouping.
     #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
     pub enum GroupingKey {
         /// `room_id`
-        #[serde(rename="room_id")]
+        #[serde(rename = "room_id")]
         RoomId,
         /// `sender`
-        #[serde(rename="sender")]
+        #[serde(rename = "sender")]
         Sender,
     }
 
@@ -132,13 +132,13 @@ pub mod search_events {
     #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
     pub enum SearchKeys {
         /// content.body
-        #[serde(rename="content.body")]
+        #[serde(rename = "content.body")]
         ContentBody,
         /// content.name
-        #[serde(rename="content.name")]
+        #[serde(rename = "content.name")]
         ContentName,
         /// content.topic
-        #[serde(rename="content.topic")]
+        #[serde(rename = "content.topic")]
         ContentTopic,
     }
 
@@ -147,10 +147,10 @@ pub mod search_events {
     pub enum OrderBy {
         /// Prioritize events by a numerical ranking of how closely they matched the search
         /// criteria.
-        #[serde(rename="rank")]
+        #[serde(rename = "rank")]
         Rank,
         /// Prioritize recent events.
-        #[serde(rename="recent")]
+        #[serde(rename = "recent")]
         Recent,
     }
 

--- a/src/r0/send.rs
+++ b/src/r0/send.rs
@@ -3,8 +3,8 @@
 /// [PUT /_matrix/client/r0/rooms/{roomId}/state/{eventType}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-state-eventtype)
 pub mod send_state_event_for_empty_key {
     use ruma_api_macros::ruma_api;
-    use ruma_identifiers::{RoomId, EventId};
     use ruma_events::EventType;
+    use ruma_identifiers::{EventId, RoomId};
     use serde_json::Value;
 
     ruma_api! {
@@ -39,8 +39,8 @@ pub mod send_state_event_for_empty_key {
 /// [PUT /_matrix/client/r0/rooms/{roomId}/state/{eventType}/{stateKey}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-state-eventtype-statekey)
 pub mod send_state_event_for_key {
     use ruma_api_macros::ruma_api;
-    use ruma_identifiers::{RoomId, EventId};
     use ruma_events::EventType;
+    use ruma_identifiers::{EventId, RoomId};
     use serde_json::Value;
 
     ruma_api! {
@@ -78,9 +78,9 @@ pub mod send_state_event_for_key {
 /// [PUT /_matrix/client/r0/rooms/{roomId}/send/{eventType}/{txnId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-send-eventtype-txnid)
 pub mod send_message_event {
     use ruma_api_macros::ruma_api;
-    use ruma_identifiers::{RoomId, EventId};
-    use ruma_events::EventType;
     use ruma_events::room::message::MessageEventContent;
+    use ruma_events::EventType;
+    use ruma_identifiers::{EventId, RoomId};
 
     ruma_api! {
         metadata {

--- a/src/r0/send.rs
+++ b/src/r0/send.rs
@@ -78,8 +78,7 @@ pub mod send_state_event_for_key {
 /// [PUT /_matrix/client/r0/rooms/{roomId}/send/{eventType}/{txnId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-send-eventtype-txnid)
 pub mod send_message_event {
     use ruma_api_macros::ruma_api;
-    use ruma_events::room::message::MessageEventContent;
-    use ruma_events::EventType;
+    use ruma_events::{room::message::MessageEventContent, EventType};
     use ruma_identifiers::{EventId, RoomId};
 
     ruma_api! {

--- a/src/r0/send.rs
+++ b/src/r0/send.rs
@@ -5,6 +5,7 @@ pub mod send_state_event_for_empty_key {
     use ruma_api_macros::ruma_api;
     use ruma_events::EventType;
     use ruma_identifiers::{EventId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
     use serde_json::Value;
 
     ruma_api! {
@@ -41,6 +42,7 @@ pub mod send_state_event_for_key {
     use ruma_api_macros::ruma_api;
     use ruma_events::EventType;
     use ruma_identifiers::{EventId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
     use serde_json::Value;
 
     ruma_api! {
@@ -80,6 +82,7 @@ pub mod send_message_event {
     use ruma_api_macros::ruma_api;
     use ruma_events::{room::message::MessageEventContent, EventType};
     use ruma_identifiers::{EventId, RoomId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/server.rs
+++ b/src/r0/server.rs
@@ -6,6 +6,7 @@ pub mod get_user_info {
 
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/session.rs
+++ b/src/r0/session.rs
@@ -4,6 +4,7 @@
 pub mod login {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::UserId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/sync.rs
+++ b/src/r0/sync.rs
@@ -5,6 +5,7 @@ pub mod get_state_events {
     use ruma_api_macros::ruma_api;
     use ruma_events::collections::only;
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -37,6 +38,7 @@ pub mod get_state_events_for_empty_key {
     use ruma_api_macros::ruma_api;
     use ruma_events::EventType;
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -70,6 +72,7 @@ pub mod get_state_events_for_key {
     use ruma_api_macros::ruma_api;
     use ruma_events::EventType;
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -106,6 +109,7 @@ pub mod get_member_events {
     use ruma_api_macros::ruma_api;
     use ruma_events::room::member::MemberEvent;
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -135,6 +139,7 @@ pub mod get_message_events {
     use ruma_api_macros::ruma_api;
     use ruma_events::collections::only;
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -204,8 +209,9 @@ pub mod sync_events {
         stripped,
     };
     use ruma_identifiers::RoomId;
+    use serde_derive::{Deserialize, Serialize};
 
-    use r0::filter::FilterDefinition;
+    use crate::r0::filter::FilterDefinition;
 
     ruma_api! {
         metadata {

--- a/src/r0/sync.rs
+++ b/src/r0/sync.rs
@@ -186,10 +186,10 @@ pub mod get_message_events {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub enum Direction {
         /// Return events backwards in time from the requested `from` token.
-        #[serde(rename="b")]
+        #[serde(rename = "b")]
         Backward,
         /// Return events forwards in time from the requested `from` token.
-        #[serde(rename="f")]
+        #[serde(rename = "f")]
         Forward,
     }
 }
@@ -199,7 +199,10 @@ pub mod sync_events {
     use std::collections::HashMap;
 
     use ruma_api_macros::ruma_api;
-    use ruma_events::{collections::{all, only}, stripped};
+    use ruma_events::{
+        collections::{all, only},
+        stripped,
+    };
     use ruma_identifiers::RoomId;
 
     use r0::filter::FilterDefinition;
@@ -252,7 +255,7 @@ pub mod sync_events {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub enum SetPresence {
         /// Do not set the presence of the user calling this API.
-        #[serde(rename="offline")]
+        #[serde(rename = "offline")]
         Offline,
     }
 

--- a/src/r0/tag.rs
+++ b/src/r0/tag.rs
@@ -4,7 +4,7 @@
 pub mod create_tag {
     use ruma_api_macros::ruma_api;
     use ruma_events::tag::TagInfo;
-    use ruma_identifiers::{UserId, RoomId};
+    use ruma_identifiers::{RoomId, UserId};
 
     ruma_api! {
         metadata {
@@ -39,7 +39,7 @@ pub mod create_tag {
 pub mod get_tags {
     use ruma_api_macros::ruma_api;
     use ruma_events::tag::TagEventContent;
-    use ruma_identifiers::{UserId, RoomId};
+    use ruma_identifiers::{RoomId, UserId};
 
     ruma_api! {
         metadata {
@@ -70,7 +70,7 @@ pub mod get_tags {
 /// [DELETE /_matrix/client/r0/user/{userId}/rooms/{roomId}/tags/{tag}](https://matrix.org/docs/spec/client_server/r0.2.0.html#delete-matrix-client-r0-user-userid-rooms-roomid-tags-tag)
 pub mod delete_tag {
     use ruma_api_macros::ruma_api;
-    use ruma_identifiers::{UserId, RoomId};
+    use ruma_identifiers::{RoomId, UserId};
 
     ruma_api! {
         metadata {

--- a/src/r0/tag.rs
+++ b/src/r0/tag.rs
@@ -5,6 +5,7 @@ pub mod create_tag {
     use ruma_api_macros::ruma_api;
     use ruma_events::tag::TagInfo;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -40,6 +41,7 @@ pub mod get_tags {
     use ruma_api_macros::ruma_api;
     use ruma_events::tag::TagEventContent;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {
@@ -71,6 +73,7 @@ pub mod get_tags {
 pub mod delete_tag {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/typing.rs
+++ b/src/r0/typing.rs
@@ -4,6 +4,7 @@
 pub mod create_typing_event {
     use ruma_api_macros::ruma_api;
     use ruma_identifiers::{RoomId, UserId};
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/r0/typing.rs
+++ b/src/r0/typing.rs
@@ -3,7 +3,7 @@
 /// [PUT /_matrix/client/r0/rooms/{roomId}/typing/{userId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-typing-userid)
 pub mod create_typing_event {
     use ruma_api_macros::ruma_api;
-    use ruma_identifiers::{UserId, RoomId};
+    use ruma_identifiers::{RoomId, UserId};
 
     ruma_api! {
         metadata {

--- a/src/r0/voip.rs
+++ b/src/r0/voip.rs
@@ -3,6 +3,7 @@
 /// [GET /_matrix/client/r0/voip/turnServer](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-voip-turnserver)
 pub mod get_turn_server_info {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {

--- a/src/unversioned.rs
+++ b/src/unversioned.rs
@@ -3,6 +3,7 @@
 /// [GET /_matrix/client/versions](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-versions)
 pub mod get_supported_versions {
     use ruma_api_macros::ruma_api;
+    use serde_derive::{Deserialize, Serialize};
 
     ruma_api! {
         metadata {


### PR DESCRIPTION
This PR includes an a re-run of `cargo fmt` without any changes and the move to nested imports that I already did for most other ruma crates but forgot for this one as separate commits.