### PR TITLE
Replace serde_derive by re-exports in serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ ruma-api-macros = "0.3.0"
 ruma-events = "0.11.0"
 ruma-identifiers = "0.11.0"
 ruma-signatures = "0.4.1"
-serde = "1.0.80"
-serde_derive = "1.0.80"
-serde_json = "1.0.33"
+serde_json = "1.0.38"
 serde_urlencoded = "0.5.4"
 url = "1.7.2"
+
+[dependencies.serde]
+version = "1.0.87"
+features = ["derive"]

--- a/src/r0/account/change_password.rs
+++ b/src/r0/account/change_password.rs
@@ -1,7 +1,7 @@
 //! [POST /_matrix/client/r0/account/password](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-password)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/account/register.rs
+++ b/src/r0/account/register.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/account/request_password_change_token.rs
+++ b/src/r0/account/request_password_change_token.rs
@@ -1,7 +1,7 @@
 //! [POST /_matrix/client/r0/account/password/email/requestToken](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-password-email-requesttoken)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/account/request_register_token.rs
+++ b/src/r0/account/request_register_token.rs
@@ -1,7 +1,7 @@
 //! [POST /_matrix/client/r0/register/email/requestToken](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-register-email-requesttoken)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/alias/create_alias.rs
+++ b/src/r0/alias/create_alias.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomAliasId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/alias/delete_alias.rs
+++ b/src/r0/alias/delete_alias.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::RoomAliasId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/alias/get_alias.rs
+++ b/src/r0/alias/get_alias.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomAliasId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/config/set_global_account_data.rs
+++ b/src/r0/config/set_global_account_data.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 ruma_api! {

--- a/src/r0/config/set_room_account_data.rs
+++ b/src/r0/config/set_room_account_data.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 ruma_api! {

--- a/src/r0/contact/create_contact.rs
+++ b/src/r0/contact/create_contact.rs
@@ -1,7 +1,7 @@
 //! [POST /_matrix/client/r0/account/3pid](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-3pid)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/contact/get_contacts.rs
+++ b/src/r0/contact/get_contacts.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/client/r0/account/3pid](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-account-3pid)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/contact/request_contact_verification_token.rs
+++ b/src/r0/contact/request_contact_verification_token.rs
@@ -1,7 +1,7 @@
 //! [POST /_matrix/client/r0/account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-3pid-email-requesttoken)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/context/get_context.rs
+++ b/src/r0/context/get_context.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::collections::only;
 use ruma_identifiers::{EventId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/directory/get_public_rooms.rs
+++ b/src/r0/directory/get_public_rooms.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomAliasId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/filter.rs
+++ b/src/r0/filter.rs
@@ -4,7 +4,7 @@ pub mod create_filter;
 pub mod get_filter;
 
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// Format to use for returned events
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]

--- a/src/r0/filter/create_filter.rs
+++ b/src/r0/filter/create_filter.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::FilterDefinition;
 

--- a/src/r0/filter/get_filter.rs
+++ b/src/r0/filter/get_filter.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::FilterDefinition;
 

--- a/src/r0/media/create_content.rs
+++ b/src/r0/media/create_content.rs
@@ -1,7 +1,7 @@
 //! [POST /_matrix/media/r0/upload](https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-media-r0-upload)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/media/get_content.rs
+++ b/src/r0/media/get_content.rs
@@ -3,7 +3,7 @@
 //! [GET /_matrix/media/r0/download/{serverName}/{mediaId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-media-r0-download-servername-mediaid)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/media/get_content_thumbnail.rs
+++ b/src/r0/media/get_content_thumbnail.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/media/r0/thumbnail/{serverName}/{mediaId}](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-media-r0-thumbnail-servername-mediaid)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// The desired resizing method.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/src/r0/membership.rs
+++ b/src/r0/membership.rs
@@ -11,7 +11,7 @@ pub mod leave_room;
 pub mod unban_user;
 
 use ruma_signatures::Signatures;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 // TODO: spec requires a nesting ThirdPartySigned { signed: Signed { mxid: ..., ... } }
 //       for join_room_by_id_or_alias but not for join_room_by_id, inconsistency?

--- a/src/r0/membership/ban_user.rs
+++ b/src/r0/membership/ban_user.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/membership/forget_room.rs
+++ b/src/r0/membership/forget_room.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/membership/invite_user.rs
+++ b/src/r0/membership/invite_user.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/membership/join_room_by_id.rs
+++ b/src/r0/membership/join_room_by_id.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::ThirdPartySigned;
 

--- a/src/r0/membership/join_room_by_id_or_alias.rs
+++ b/src/r0/membership/join_room_by_id_or_alias.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, RoomIdOrAliasId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::ThirdPartySigned;
 

--- a/src/r0/membership/joined_rooms.rs
+++ b/src/r0/membership/joined_rooms.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/membership/kick_user.rs
+++ b/src/r0/membership/kick_user.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/membership/leave_room.rs
+++ b/src/r0/membership/leave_room.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/membership/unban_user.rs
+++ b/src/r0/membership/unban_user.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/presence/get_presence.rs
+++ b/src/r0/presence/get_presence.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::presence::PresenceState;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/presence/get_subscribed_presences.rs
+++ b/src/r0/presence/get_subscribed_presences.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::presence::PresenceEvent;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/presence/set_presence.rs
+++ b/src/r0/presence/set_presence.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::presence::PresenceState;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/presence/update_presence_subscriptions.rs
+++ b/src/r0/presence/update_presence_subscriptions.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/profile/get_avatar_url.rs
+++ b/src/r0/profile/get_avatar_url.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/profile/get_display_name.rs
+++ b/src/r0/profile/get_display_name.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/profile/get_profile.rs
+++ b/src/r0/profile/get_profile.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/profile/set_avatar_url.rs
+++ b/src/r0/profile/set_avatar_url.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/profile/set_display_name.rs
+++ b/src/r0/profile/set_display_name.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/receipt/create_receipt.rs
+++ b/src/r0/receipt/create_receipt.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Error as FmtError, Formatter};
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{EventId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/redact/redact_event.rs
+++ b/src/r0/redact/redact_event.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{EventId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/room/create_room.rs
+++ b/src/r0/room/create_room.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/search/search_events.rs
+++ b/src/r0/search/search_events.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use ruma_api_macros::ruma_api;
 use ruma_events::collections::all::Event;
 use ruma_identifiers::{EventId, RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::r0::filter::RoomEventFilter;
 

--- a/src/r0/send/send_message_event.rs
+++ b/src/r0/send/send_message_event.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::{room::message::MessageEventContent, EventType};
 use ruma_identifiers::{EventId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/send/send_state_event_for_empty_key.rs
+++ b/src/r0/send/send_state_event_for_empty_key.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::EventType;
 use ruma_identifiers::{EventId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 ruma_api! {

--- a/src/r0/send/send_state_event_for_key.rs
+++ b/src/r0/send/send_state_event_for_key.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::EventType;
 use ruma_identifiers::{EventId, RoomId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 ruma_api! {

--- a/src/r0/server/get_user_info.rs
+++ b/src/r0/server/get_user_info.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/session/login.rs
+++ b/src/r0/session/login.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/sync/get_member_events.rs
+++ b/src/r0/sync/get_member_events.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::room::member::MemberEvent;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/sync/get_message_events.rs
+++ b/src/r0/sync/get_message_events.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::collections::only;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/sync/get_state_events.rs
+++ b/src/r0/sync/get_state_events.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::collections::only;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/sync/get_state_events_for_empty_key.rs
+++ b/src/r0/sync/get_state_events_for_empty_key.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::EventType;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/sync/get_state_events_for_key.rs
+++ b/src/r0/sync/get_state_events_for_key.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::EventType;
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/sync/sync_events.rs
+++ b/src/r0/sync/sync_events.rs
@@ -8,7 +8,7 @@ use ruma_events::{
     stripped,
 };
 use ruma_identifiers::RoomId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::r0::filter::FilterDefinition;
 

--- a/src/r0/tag/create_tag.rs
+++ b/src/r0/tag/create_tag.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::tag::TagInfo;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/tag/delete_tag.rs
+++ b/src/r0/tag/delete_tag.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/tag/get_tags.rs
+++ b/src/r0/tag/get_tags.rs
@@ -3,7 +3,7 @@
 use ruma_api_macros::ruma_api;
 use ruma_events::tag::TagEventContent;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/typing/create_typing_event.rs
+++ b/src/r0/typing/create_typing_event.rs
@@ -2,7 +2,7 @@
 
 use ruma_api_macros::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/r0/voip/get_turn_server_info.rs
+++ b/src/r0/voip/get_turn_server_info.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/client/r0/voip/turnServer](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-voip-turnserver)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {

--- a/src/unversioned/get_supported_versions.rs
+++ b/src/unversioned/get_supported_versions.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/client/versions](https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-versions)
 
 use ruma_api_macros::ruma_api;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ruma_api! {
     metadata {


### PR DESCRIPTION
Same as https://github.com/ruma/ruma-events/pull/24, although it's only for future-proofing / a nicer dependency tree here as I don't think we currently import the `Deserialize` / `Serialize` traits and proc-macros in the same scope anywhere.