### PR TITLE
Add application service extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Breaking changes:
 
 * Move `r0::directory::get_public_rooms::PublicRoomsChunk` to `r0::directory::PublicRoomsChunk`
+* Move `r0::room::create_room::Visibility` to `r0::room::Visibility`
 * Our Minimum Supported Rust Version is now 1.36.0
 
 Improvements:
@@ -10,3 +11,4 @@ Improvements:
 * Update `r0::directory::get_public_rooms` from r0.3.0 to r0.6.0
 * Add `r0::directory::get_public_rooms_filtered` (introduced upstream in r0.3.0)
 * Add `filter` optional parameter to `r0::sync::get_message_events` (introduced upstream in r0.3.0)
+* Add `r0::appservice::set_room_visibility` (part of application service extensions for the client-server API)

--- a/src/r0.rs
+++ b/src/r0.rs
@@ -2,6 +2,7 @@
 
 pub mod account;
 pub mod alias;
+pub mod appservice;
 pub mod config;
 pub mod contact;
 pub mod context;

--- a/src/r0/appservice.rs
+++ b/src/r0/appservice.rs
@@ -1,0 +1,3 @@
+//! Endpoints part of the application service extension of the client-server API
+
+pub mod set_room_visibility;

--- a/src/r0/appservice/set_room_visibility.rs
+++ b/src/r0/appservice/set_room_visibility.rs
@@ -1,0 +1,30 @@
+//! [PUT /_matrix/client/r0/directory/list/appservice/{networkId}/{roomId}](https://matrix.org/docs/spec/application_service/r0.1.2#put-matrix-client-r0-directory-list-appservice-networkid-roomid)
+
+use ruma_api::ruma_api;
+use ruma_identifiers::RoomId;
+
+use crate::r0::room::Visibility;
+
+ruma_api! {
+    metadata {
+        description: "Updates the visibility of a given room on the application service's room directory.",
+        method: PUT,
+        name: "set_room_visibility",
+        path: "/_matrix/client/r0/directory/list/appservice/:network_id/:room_id",
+        rate_limited: false,
+        requires_authentication: true,
+    }
+
+    request {
+        /// The protocol (network) ID to update the room list for.
+        #[ruma_api(path)]
+        pub network_id: String,
+        /// The room ID to add to the directory.
+        #[ruma_api(path)]
+        pub room_id: RoomId,
+        /// Whether the room should be visible (public) in the directory or not (private).
+        pub visibility: Visibility,
+    }
+
+    response {}
+}

--- a/src/r0/room.rs
+++ b/src/r0/room.rs
@@ -1,3 +1,15 @@
 //! Endpoints for room creation.
 
 pub mod create_room;
+
+use serde::{Deserialize, Serialize};
+
+/// Whether or not a newly created room will be listed in the room directory.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Visibility {
+    /// Indicates that the room will be shown in the published room list.
+    Public,
+    /// Indicates that the room will not be shown in the published room list.
+    Private,
+}

--- a/src/r0/room/create_room.rs
+++ b/src/r0/room/create_room.rs
@@ -4,6 +4,8 @@ use ruma_api::ruma_api;
 use ruma_identifiers::{RoomId, UserId};
 use serde::{Deserialize, Serialize};
 
+use super::Visibility;
+
 ruma_api! {
     metadata {
         description: "Create a new room.",
@@ -71,14 +73,4 @@ pub enum RoomPreset {
     PublicChat,
     /// Same as `PrivateChat`, but all initial invitees get the same power level as the creator.
     TrustedPrivateChat,
-}
-
-/// Whether or not a newly created room will be listed in the room directory.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Visibility {
-    /// Indicates that the room will be shown in the published room list.
-    Public,
-    /// Indicates that the room from the published room list.
-    Private,
 }


### PR DESCRIPTION
The application service specification defines a single extension for the
client-server API. This endpoint can only be used by application
services.