### PR TITLE
Fix r0::session::get_login_types::Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Breaking changes:
+
+* Fix `r0::session::get_login_types`
+
 # 0.6.0
 
 Breaking changes:

--- a/src/r0/session/get_login_types.rs
+++ b/src/r0/session/get_login_types.rs
@@ -17,19 +17,11 @@ ruma_api! {
 
     response {
         /// The homeserver's supported login types.
-        pub flows: Vec<LoginFlow>
+        pub flows: Vec<LoginType>
     }
 }
 
-/// A supported login type in a homeserver
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct LoginFlow {
-    /// The login type.
-    #[serde(rename = "type")]
-    pub login_type: LoginType,
-}
-
-/// The authentication mechanism.
+/// An authentication mechanism.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum LoginType {
@@ -39,4 +31,17 @@ pub enum LoginType {
     /// Token-based login.
     #[serde(rename = "m.login.token")]
     Token,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LoginType;
+
+    #[test]
+    fn deserialize_login_type() {
+        assert_eq!(
+            serde_json::from_str::<LoginType>(r#" {"type": "m.login.password"} "#).unwrap(),
+            LoginType::Password,
+        );
+    }
 }


### PR DESCRIPTION
The previous version was expecting one level of nesting too many, i.e.:

    {"type": {"type": "m.login.password"}}

This is a breaking change, so bump the version number too. (Let me know if I shouldn't do that; I'm not sure what Ruma's versioning policy is.)

Also, I kept the name `LoginType` rather than `LoginFlow`, because once the user-interactive authentication API with multiple-stage flows are supported, a `LoginFlow` will conceptually be a `Vec<LoginType>`.

cc @jplatte