### PR TITLE
sync_events: Create an empty heroes vector the response doesn't contain it.

### DIFF
--- a/src/r0/sync/sync_events.rs
+++ b/src/r0/sync/sync_events.rs
@@ -260,7 +260,7 @@ pub struct Ephemeral {
 pub struct RoomSummary {
     /// Users which can be used to generate a room name if the room does not have
     /// one. Required if room name or canonical aliases are not set or empty.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub heroes: Vec<String>,
     /// Number of users whose membership status is `join`.
     /// Required if field has changed since last sync; otherwise, it may be

--- a/src/r0/sync/sync_events.rs
+++ b/src/r0/sync/sync_events.rs
@@ -260,15 +260,17 @@ pub struct Ephemeral {
 pub struct RoomSummary {
     /// Users which can be used to generate a room name if the room does not have
     /// one. Required if room name or canonical aliases are not set or empty.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(rename = "m.heroes", default, skip_serializing_if = "Vec::is_empty")]
     pub heroes: Vec<String>,
     /// Number of users whose membership status is `join`.
     /// Required if field has changed since last sync; otherwise, it may be
     /// omitted.
+    #[serde(rename = "m.joined_member_count")]
     pub joined_member_count: Option<UInt>,
     /// Number of users whose membership status is `invite`.
     /// Required if field has changed since last sync; otherwise, it may be
     /// omitted.
+    #[serde(rename = "m.invited_member_count")]
     pub invited_member_count: Option<UInt>,
 }
 


### PR DESCRIPTION
The heroes map is strictly optional and as is deserialization might fail
for the whole response unless we allow it to be optional.