### PR TITLE
Update register endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Breaking changes:
 
 * Add `server_name` parameter to `r0::join::join_room_by_id_or_alias` 
+* Update `r0::account::register` endpoint:
+  * Remove `bind_email` request field (removed in r0.6.0)
+  * Remove `inhibit_login` request field, make `access_token` and `device_id` response fields optional (added in r0.4.0)
+  * Remove deprecated `home_server` response field (removed in r0.4.0)
 
 # 0.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Breaking changes:
   * Remove deprecated `home_server` response field (removed in r0.4.0)
 * Add `auth_parameters` to `r0::account::AuthenticationData` 
 
+Improvements:
+
+* Add types for User-Interactive Authentication API: `r0::account::{UserInteractiveAuthenticationInfo, AuthenticationFlow}`
+
 # 0.7.2
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
   * Remove `bind_email` request field (removed in r0.6.0)
   * Remove `inhibit_login` request field, make `access_token` and `device_id` response fields optional (added in r0.4.0)
   * Remove deprecated `home_server` response field (removed in r0.4.0)
+* Add `auth_parameters` to `r0::account::AuthenticationData` 
 
 # 0.7.2
 

--- a/src/r0/account.rs
+++ b/src/r0/account.rs
@@ -17,6 +17,8 @@ pub mod unbind_3pid;
 
 pub mod whoami;
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// Additional authentication information for the user-interactive authentication API.
@@ -27,6 +29,9 @@ pub struct AuthenticationData {
     pub kind: String,
     /// The value of the session key given by the homeserver.
     pub session: Option<String>,
+    /// Parameters submitted for a particular authentication stage.
+    #[serde(flatten)]
+    pub auth_parameters: BTreeMap<String, serde_json::Value>,
 }
 
 /// Additional authentication information for requestToken endpoints.

--- a/src/r0/account.rs
+++ b/src/r0/account.rs
@@ -34,6 +34,31 @@ pub struct AuthenticationData {
     pub auth_parameters: BTreeMap<String, serde_json::Value>,
 }
 
+/// Information about available authentication flows and status for
+/// User-Interactive Authenticiation API.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UserInteractiveAuthenticationInfo {
+    /// List of authentication flows available for this endpoint.
+    pub flows: Vec<AuthenticationFlow>,
+    /// List of stages in the current flow completed by the client.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub completed: Vec<String>,
+    /// Authentication parameters required for the client to complete authentication.
+    pub params: serde_json::Value,
+    /// Session key for client to use to complete authentication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+}
+
+/// Description of steps required to authenticate via the User-Interactive
+/// Authentication API.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AuthenticationFlow {
+    /// Ordered list of stages required to complete authentication.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stages: Vec<String>,
+}
+
 /// Additional authentication information for requestToken endpoints.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct IdentityServerInfo {

--- a/src/r0/account/register.rs
+++ b/src/r0/account/register.rs
@@ -19,8 +19,8 @@ ruma_api! {
     request {
         /// The desired password for the account.
         ///
-        /// Should only be empty for guest accounts.
-        // TODO: the spec says nothing about when it is actually required.
+        /// May be empty for accounts that should not be able to log in again
+        /// with a password, e.g., for guest or application service accounts.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub password: Option<String>,
         /// local part of the desired Matrix ID.

--- a/src/r0/account/register.rs
+++ b/src/r0/account/register.rs
@@ -1,4 +1,4 @@
-//! [POST /_matrix/client/r0/register](https://matrix.org/docs/spec/client_server/r0.4.0.html#post-matrix-client-r0-register)
+//! [POST /_matrix/client/r0/register](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-register)
 
 use ruma_api::ruma_api;
 use ruma_identifiers::{DeviceId, UserId};
@@ -17,10 +17,6 @@ ruma_api! {
     }
 
     request {
-        /// If true, the server binds the email used for authentication
-        /// to the Matrix ID with the ID Server.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub bind_email: Option<bool>,
         /// The desired password for the account.
         ///
         /// Should only be empty for guest accounts.
@@ -53,25 +49,28 @@ ruma_api! {
         pub auth: Option<AuthenticationData>,
         /// Kind of account to register
         ///
-        /// Defaults to `User` if ommited.
+        /// Defaults to `User` if omitted.
         #[ruma_api(query)]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub kind: Option<RegistrationKind>,
+        /// If `true`, an `access_token` and `device_id` should not be returned
+        /// from this call, therefore preventing an automatic login.
+        #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+        pub inhibit_login: bool,
     }
 
     response {
         /// An access token for the account.
         ///
         /// This access token can then be used to authorize other requests.
-        pub access_token: String,
-        /// The hostname of the homeserver on which the account has been registered.
-        pub home_server: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub access_token: Option<String>,
         /// The fully-qualified Matrix ID that has been registered.
         pub user_id: UserId,
         /// ID of the registered device.
         ///
         /// Will be the same as the corresponding parameter in the request, if one was specified.
-        pub device_id: DeviceId,
+        pub device_id: Option<DeviceId>,
     }
 
     error: crate::Error


### PR DESCRIPTION
Fixes #90, and #132.

`AuthenticationData` is also used in `/register`, so I combined the changes in the same PR. I can split it up the commits into separate PRs if necessary.