### PR TITLE
sync_events/get_message_events: ser/de filters to string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,5 @@ ruma-events = "0.18.0"
 ruma-identifiers = "0.14.1"
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = "1.0.50"
-serde_urlencoded = "0.6.1"
 strum = { version = "0.18.0", features = ["derive"] }
 url = { version = "2.1.1", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ ruma-events = "0.18.0"
 ruma-identifiers = "0.14.1"
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = "1.0.50"
+serde_urlencoded = "0.6.1"
 strum = { version = "0.18.0", features = ["derive"] }
 url = { version = "2.1.1", features = ["serde"] }

--- a/src/r0/message/get_message_events.rs
+++ b/src/r0/message/get_message_events.rs
@@ -76,3 +76,80 @@ pub enum Direction {
     #[serde(rename = "f")]
     Forward,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Direction, Request};
+
+    use std::convert::{TryFrom, TryInto};
+
+    use ruma_identifiers::RoomId;
+
+    use crate::r0::filter::{LazyLoadOptions, RoomEventFilter};
+
+    #[test]
+    fn test_serialize_some_room_event_filter() {
+        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
+        let filter = RoomEventFilter {
+            lazy_load_options: LazyLoadOptions::Enabled {
+                include_redundant_members: true,
+            },
+            rooms: Some(vec![room_id.clone()]),
+            not_rooms: vec!["room".into(), "room2".into(), "room3".into()],
+            not_types: vec!["type".into()],
+            ..Default::default()
+        };
+        let req = Request {
+            room_id,
+            from: "token".into(),
+            to: Some("token2".into()),
+            dir: Direction::Backward,
+            limit: Some(js_int::UInt::min_value()),
+            filter: Some(filter),
+        };
+
+        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        assert_eq!(
+            "from=token&to=token2&dir=b&limit=0&filter=%7B%22not_types%22%3A%5B%22type%22%5D%2C%22not_rooms%22%3A%5B%22room%22%2C%22room2%22%2C%22room3%22%5D%2C%22rooms%22%3A%5B%22%21roomid%3Aexample.org%22%5D%2C%22lazy_load_members%22%3Atrue%2C%22include_redundant_members%22%3Atrue%7D",
+            request.uri().query().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_serialize_none_room_event_filter() {
+        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
+        let req = Request {
+            room_id,
+            from: "token".into(),
+            to: Some("token2".into()),
+            dir: Direction::Backward,
+            limit: Some(js_int::UInt::min_value()),
+            filter: None,
+        };
+
+        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        assert_eq!(
+            "from=token&to=token2&dir=b&limit=0",
+            request.uri().query().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_serialize_default_room_event_filter() {
+        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
+        let req = Request {
+            room_id,
+            from: "token".into(),
+            to: Some("token2".into()),
+            dir: Direction::Backward,
+            limit: Some(js_int::UInt::min_value()),
+            filter: Some(RoomEventFilter::default()),
+        };
+
+        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        assert_eq!(
+            "from=token&to=token2&dir=b&limit=0&filter=%7B%7D",
+            request.uri().query().unwrap(),
+        );
+    }
+}

--- a/src/r0/message/get_message_events.rs
+++ b/src/r0/message/get_message_events.rs
@@ -48,7 +48,11 @@ ruma_api! {
         pub limit: Option<UInt>,
         /// A RoomEventFilter to filter returned events with.
         #[ruma_api(query)]
-        #[serde(with = "crate::serde::json_string", skip_serializing_if = "Option::is_none")]
+        #[serde(
+            with = "crate::serde::json_string",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
         pub filter: Option<RoomEventFilter>,
     }
 

--- a/src/r0/message/get_message_events.rs
+++ b/src/r0/message/get_message_events.rs
@@ -49,6 +49,7 @@ ruma_api! {
         /// A RoomEventFilter to filter returned events with.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ruma_api(query)]
+        #[serde(with = "crate::serde::json_string")]
         pub filter: Option<RoomEventFilter>,
     }
 

--- a/src/r0/message/get_message_events.rs
+++ b/src/r0/message/get_message_events.rs
@@ -47,9 +47,8 @@ ruma_api! {
         #[ruma_api(query)]
         pub limit: Option<UInt>,
         /// A RoomEventFilter to filter returned events with.
-        #[serde(skip_serializing_if = "Option::is_none")]
         #[ruma_api(query)]
-        #[serde(with = "crate::serde::json_string")]
+        #[serde(with = "crate::serde::json_string", skip_serializing_if = "Option::is_none")]
         pub filter: Option<RoomEventFilter>,
     }
 

--- a/src/r0/sync/sync_events.rs
+++ b/src/r0/sync/sync_events.rs
@@ -122,37 +122,11 @@ pub enum Filter {
     // FilterDefinition is the first variant, JSON decoding is attempted first which is almost
     // functionally equivalent to looking at whether the first symbol is a '{' as the spec says.
     // (there are probably some corner cases like leading whitespace)
-    #[serde(with = "filter_def_serde")]
+    #[serde(with = "crate::serde::json_string")]
     /// A complete filter definition serialized to JSON.
     FilterDefinition(FilterDefinition),
     /// The ID of a filter saved on the server.
     FilterId(String),
-}
-
-/// Serialization and deserialization logic for filter definitions.
-mod filter_def_serde {
-    use serde::{de::Error as _, ser::Error as _, Deserialize, Deserializer, Serializer};
-
-    use crate::r0::filter::FilterDefinition;
-
-    /// Serialization logic for filter definitions.
-    pub fn serialize<S>(filter_def: &FilterDefinition, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let string = serde_json::to_string(filter_def).map_err(S::Error::custom)?;
-        serializer.serialize_str(&string)
-    }
-
-    /// Deserialization logic for filter definitions.
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<FilterDefinition, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let filter_str = <&str>::deserialize(deserializer)?;
-
-        serde_json::from_str(filter_str).map_err(D::Error::custom)
-    }
 }
 
 /// Updates to rooms.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,6 +1,7 @@
 //! Modules to hold functions for de-/serializing remote types
 
 pub mod duration;
+pub mod json_string;
 
 pub fn is_default<T: Default + PartialEq>(val: &T) -> bool {
     val == &T::default()

--- a/src/serde/json_string.rs
+++ b/src/serde/json_string.rs
@@ -2,10 +2,9 @@
 //! Delegates to `js_int::UInt` to ensure integer size is within bounds.
 
 use serde::{
-    de::{Error as _, Deserialize, Deserializer, DeserializeOwned},
+    de::{Deserialize, DeserializeOwned, Deserializer, Error as _},
     ser::{Error as _, Serialize, Serializer},
 };
-use serde_json;
 
 /// Serialize a filter into a json string.
 pub fn serialize<T, S>(filter: T, serializer: S) -> Result<S::Ok, S::Error>
@@ -33,18 +32,20 @@ mod tests {
 
     use ruma_identifiers::RoomId;
 
-    use crate::r0::message::get_message_events::{Request, Direction};
     use crate::r0::filter::{LazyLoadOptions, RoomEventFilter};
+    use crate::r0::message::get_message_events::{Direction, Request};
 
     #[test]
     fn test_serialize_some_room_event_filter() {
         let room_id = RoomId::try_from("!roomid:example.org").unwrap();
         let filter = RoomEventFilter {
-            lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: true, },
-            rooms: Some(vec![ room_id.clone() ]),
-            not_rooms: vec![ "room".into(), "room2".into(), "room3".into() ],
-            not_types: vec![ "type".into() ],
-            .. Default::default()
+            lazy_load_options: LazyLoadOptions::Enabled {
+                include_redundant_members: true,
+            },
+            rooms: Some(vec![room_id.clone()]),
+            not_rooms: vec!["room".into(), "room2".into(), "room3".into()],
+            not_types: vec!["type".into()],
+            ..Default::default()
         };
         let req = Request {
             room_id,
@@ -90,5 +91,4 @@ mod tests {
         let request: http::Request<Vec<u8>> = req.try_into().unwrap();
         println!("{:?}", request.uri());
     }
-
 }

--- a/src/serde/json_string.rs
+++ b/src/serde/json_string.rs
@@ -1,12 +1,10 @@
-//! De-/serialization functions for `Option<RoomEventFilter>` objects.
-//! Delegates to `js_int::UInt` to ensure integer size is within bounds.
+//! De-/serialization functions to and from json strings, allows the type to be used as a query string.
 
 use serde::{
     de::{Deserialize, DeserializeOwned, Deserializer, Error as _},
     ser::{Error as _, Serialize, Serializer},
 };
 
-/// Serialize a filter into a json string.
 pub fn serialize<T, S>(filter: T, serializer: S) -> Result<S::Ok, S::Error>
 where
     T: Serialize,
@@ -16,7 +14,6 @@ where
     serializer.serialize_str(&json)
 }
 
-/// Deserializes a filter from a json string.
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: DeserializeOwned,
@@ -24,71 +21,4 @@ where
 {
     let s = String::deserialize(deserializer)?;
     serde_json::from_str(&s).map_err(D::Error::custom)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::convert::{TryFrom, TryInto};
-
-    use ruma_identifiers::RoomId;
-
-    use crate::r0::filter::{LazyLoadOptions, RoomEventFilter};
-    use crate::r0::message::get_message_events::{Direction, Request};
-
-    #[test]
-    fn test_serialize_some_room_event_filter() {
-        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
-        let filter = RoomEventFilter {
-            lazy_load_options: LazyLoadOptions::Enabled {
-                include_redundant_members: true,
-            },
-            rooms: Some(vec![room_id.clone()]),
-            not_rooms: vec!["room".into(), "room2".into(), "room3".into()],
-            not_types: vec!["type".into()],
-            ..Default::default()
-        };
-        let req = Request {
-            room_id,
-            from: "token".into(),
-            to: Some("token2".into()),
-            dir: Direction::Backward,
-            limit: Some(js_int::UInt::min_value()),
-            filter: Some(filter),
-        };
-
-        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
-        println!("{:?}", request.uri().query());
-    }
-
-    #[test]
-    fn test_serialize_none_room_event_filter() {
-        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
-        let req = Request {
-            room_id,
-            from: "token".into(),
-            to: Some("token2".into()),
-            dir: Direction::Backward,
-            limit: Some(js_int::UInt::min_value()),
-            filter: None,
-        };
-
-        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
-        println!("{:?}", request.uri());
-    }
-
-    #[test]
-    fn test_serialize_default_room_event_filter() {
-        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
-        let req = Request {
-            room_id,
-            from: "token".into(),
-            to: Some("token2".into()),
-            dir: Direction::Backward,
-            limit: Some(js_int::UInt::min_value()),
-            filter: Some(RoomEventFilter::default()),
-        };
-
-        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
-        println!("{:?}", request.uri());
-    }
 }

--- a/src/serde/json_string.rs
+++ b/src/serde/json_string.rs
@@ -1,0 +1,103 @@
+//! De-/serialization functions for `Option<RoomEventFilter>` objects.
+//! Delegates to `js_int::UInt` to ensure integer size is within bounds.
+
+use serde::{
+    de::{Error as _, Deserialize, Deserializer, DeserializeOwned},
+    ser::{Error as _, Serialize, Serializer},
+};
+use serde_json;
+
+/// Serialize a filter into a query string.
+pub fn serialize<T, S>(filter: T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: Serialize,
+    S: Serializer,
+{
+    let json = serde_json::to_string(&filter).map_err(S::Error::custom)?;
+    serializer.serialize_str(&json)
+}
+
+/// Deserializes a filter from a query string.
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    serde_json::from_str(&s).map_err(D::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::{TryFrom, TryInto};
+
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use ruma_identifiers::RoomId;
+
+    use crate::r0::message::get_message_events::{Request, Direction};
+    use crate::r0::filter::{LazyLoadOptions, RoomEventFilter};
+
+    #[test]
+    fn test_serialize_some_room_event_filter() {
+        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
+        let filter = RoomEventFilter {
+            lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: true, },
+            rooms: Some(vec![ room_id.clone() ]),
+            not_rooms: vec![ "room".into(), "room2".into(), "room3".into() ],
+            not_types: vec![ "type".into() ],
+            .. Default::default()
+        };
+        let req = Request {
+            room_id,
+            from: "token".into(),
+            to: Some("token2".into()),
+            dir: Direction::Backward,
+            limit: Some(js_int::UInt::min_value()),
+            filter: Some(filter),
+        };
+
+        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        println!("{:?}", request.uri().query());
+    }
+
+    #[test]
+    fn test_serialize_none_room_event_filter() {
+        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
+        let filter = RoomEventFilter {
+            lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: true, },
+            rooms: Some(vec![ room_id.clone() ]),
+            not_rooms: vec![ "room".into() ],
+            not_types: vec![ "type".into() ],
+            .. Default::default()
+        };
+        let req = Request {
+            room_id,
+            from: "token".into(),
+            to: Some("token2".into()),
+            dir: Direction::Backward,
+            limit: Some(js_int::UInt::min_value()),
+            filter: None,
+        };
+
+        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        println!("{:?}", request.uri());
+    }
+
+    #[test]
+    fn test_serialize_default_room_event_filter() {
+        let room_id = RoomId::try_from("!roomid:example.org").unwrap();
+        let req = Request {
+            room_id,
+            from: "token".into(),
+            to: Some("token2".into()),
+            dir: Direction::Backward,
+            limit: Some(js_int::UInt::min_value()),
+            filter: Some(RoomEventFilter::default()),
+        };
+
+        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        println!("{:?}", request.uri());
+    }
+
+}

--- a/src/serde/json_string.rs
+++ b/src/serde/json_string.rs
@@ -7,7 +7,7 @@ use serde::{
 };
 use serde_json;
 
-/// Serialize a filter into a query string.
+/// Serialize a filter into a json string.
 pub fn serialize<T, S>(filter: T, serializer: S) -> Result<S::Ok, S::Error>
 where
     T: Serialize,
@@ -17,7 +17,7 @@ where
     serializer.serialize_str(&json)
 }
 
-/// Deserializes a filter from a query string.
+/// Deserializes a filter from a json string.
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: DeserializeOwned,
@@ -31,8 +31,6 @@ where
 mod tests {
     use std::convert::{TryFrom, TryInto};
 
-    use serde::{Deserialize, Serialize};
-    use serde_json::json;
     use ruma_identifiers::RoomId;
 
     use crate::r0::message::get_message_events::{Request, Direction};
@@ -64,13 +62,6 @@ mod tests {
     #[test]
     fn test_serialize_none_room_event_filter() {
         let room_id = RoomId::try_from("!roomid:example.org").unwrap();
-        let filter = RoomEventFilter {
-            lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: true, },
-            rooms: Some(vec![ room_id.clone() ]),
-            not_rooms: vec![ "room".into() ],
-            not_types: vec![ "type".into() ],
-            .. Default::default()
-        };
         let req = Request {
             room_id,
             from: "token".into(),


### PR DESCRIPTION
Resolving: When trying to send a `r0::message::get_message_events::Request` using `RoomEventFilter::default()` for the filter field returns an error with inner type Query(Custom("unsupported value")).

If this is on the right track I'll turn the println's into asserts and add doc's.