### PR TITLE
client_exchange: Use room messages to send out to-device events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Breaking changes:
   * `server::get_user_info::ConnectionInfo`
   * `device::Device`
 * Change all usages of `HashMap` to `BTreeMap`
+* Change the messages type that gets sent out using the `r0::client_exchange::send_event_to_device`
+  request.
 
 Improvements:
 

--- a/src/r0/client_exchange/send_event_to_device.rs
+++ b/src/r0/client_exchange/send_event_to_device.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use ruma_api::ruma_api;
-use ruma_events::{collections::all, EventResult};
+use ruma_events::{room::message::MessageEventContent, EventResult, EventType};
 use ruma_identifiers::UserId;
 
 use super::DeviceIdOrAllDevices;
@@ -21,15 +21,15 @@ ruma_api! {
     request {
         /// Type of event being sent to each device.
         #[ruma_api(path)]
-        pub event_type: String,
+        pub event_type: EventType,
         /// A request identifier unique to the access token used to send the request.
         #[ruma_api(path)]
         pub txn_id: String,
         /// A map of users to devices to a message event to be sent to the user's
         /// device. Individual message events can be sent to devices, but all
         /// events must be of the same type.
-        #[wrap_incoming(all::Event with EventResult)]
-        pub messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, all::Event>>
+        #[wrap_incoming(MessageEventContent with EventResult)]
+        pub messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, MessageEventContent>>
     }
 
     response {}


### PR DESCRIPTION
This fixes https://github.com/ruma/ruma-client-api/issues/139.