### PR TITLE
message/state: The event id is required in the response when sending events.

### DIFF
--- a/src/r0/message/create_message_event.rs
+++ b/src/r0/message/create_message_event.rs
@@ -41,7 +41,7 @@ ruma_api! {
 
     response {
         /// A unique identifier for the event.
-        pub event_id: Option<EventId>,
+        pub event_id: EventId,
     }
 
     error: crate::Error

--- a/src/r0/state/create_state_event_for_empty_key.rs
+++ b/src/r0/state/create_state_event_for_empty_key.rs
@@ -33,7 +33,7 @@ ruma_api! {
 
     response {
         /// A unique identifier for the event.
-        pub event_id: Option<EventId>,
+        pub event_id: EventId,
     }
 
     error: crate::Error

--- a/src/r0/state/create_state_event_for_key.rs
+++ b/src/r0/state/create_state_event_for_key.rs
@@ -37,7 +37,7 @@ ruma_api! {
 
     response {
         /// A unique identifier for the event.
-        pub event_id: Option<EventId>,
+        pub event_id: EventId,
     }
 
     error: crate::Error


### PR DESCRIPTION
As per https://github.com/matrix-org/matrix-doc/pull/2525. The spec has been fixed.